### PR TITLE
fix: Use qr-scanner package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "capacitor-camera-preview": "laumair/capacitor-camera-preview#7cb9d89",
         "capacitor-secure-storage-plugin": "0.3.1",
         "hammerjs": "^2.0.8",
-        "qr-scanner": "rihardsgravis/qr-scanner",
+        "qr-scanner": "^1.2.0",
         "qrcode-svg": "^1.1.0",
         "randomstring": "^1.1.5",
         "socket.io-client": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5101,9 +5101,10 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qr-scanner@rihardsgravis/qr-scanner:
-  version "1.1.1"
-  resolved "https://codeload.github.com/rihardsgravis/qr-scanner/tar.gz/75d0b127fc1acbea4b0c4f3dafc8c47ffa6e0dfc"
+qr-scanner@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/qr-scanner/-/qr-scanner-1.2.0.tgz#845a263d167a06f6d4aaebd5b2f66b64ba460c86"
+  integrity sha512-oTuOxV/UT0O1BMyNCoWusd8B8/Za4zNvDWxTN54+s0mRvnavU0OjQiwI2o3HCuXUVGO88Ee9yY9qjrt8yUYaSw==
 
 qrcode-svg@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Uses the original `qr-scanner` package as the previous repo is no longer available