### PR TITLE
fix(android): Target API level 29

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,7 +5,7 @@ android {
     defaultConfig {
         applicationId "com.iota.selv.demo"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 10
         versionName "1.0.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Google Play now requires apps to target API level 29