### PR TITLE
fix: Fix typo in helpers

### DIFF
--- a/ui/lib/helpers.ts
+++ b/ui/lib/helpers.ts
@@ -15,7 +15,17 @@ import {
     PresentCommitmentData,
     ContactDetails
 } from '~/lib/identity';
-import { QRLink, PersonalInfo, ImmunityInfo, VisaInfo, InsuranceInfo, BankInfo, CompanyInfo, FutureCommitmentInfo, PresentCommitmentInfo } from '~/lib/store';
+import {
+    QRLink,
+    PersonalInfo,
+    ImmunityInfo,
+    VisaInfo,
+    InsuranceInfo,
+    BankInfo,
+    CompanyInfo,
+    FutureCommitmentInfo,
+    PresentCommitmentInfo
+} from '~/lib/store';
 
 import { RANDOM_USER_DATA_API_URL } from '~/lib/config';
 
@@ -305,10 +315,6 @@ export const prepareInsuranceInformation = (insuranceData: InsuranceData): Insur
     endDate: insuranceData.EndDate
 });
 
-
-
-
-
 /**
  * Prepares future commitment information
  *
@@ -319,9 +325,8 @@ export const prepareInsuranceInformation = (insuranceData: InsuranceData): Insur
  * @returns {FutureCommitmentInfo}
  */
 export const prepareFutureCommitmentInformation = (futureCommitmentData: FutureCommitmentData): FutureCommitmentInfo => ({
-    commitments: futureCommitmentData.Commitments
+    commitments: futureCommitmentData.commitments
 });
-
 
 /**
  * Prepares present commitment information
@@ -333,7 +338,7 @@ export const prepareFutureCommitmentInformation = (futureCommitmentData: FutureC
  * @returns {PresentCommitmentInfo}
  */
 export const preparePresentCommitmentInformation = (presentCommitmentData: PresentCommitmentData): PresentCommitmentInfo => ({
-    commitments: presentCommitmentData.Commitments
+    commitments: presentCommitmentData.commitments
 });
 
 /**


### PR DESCRIPTION
Fixes `tsc` errors:

```
ui/lib/helpers.ts:322:39 - error TS2551: Property 'Commitments' does not exist on type 'FutureCommitmentData'. Did you mean 'commitments'?

322     commitments: futureCommitmentData.Commitments
                                          ~~~~~~~~~~~

  ui/lib/identity/index.ts:164:5
    164     commitments: Commitment[]
            ~~~~~~~~~~~
    'commitments' is declared here.

ui/lib/helpers.ts:336:40 - error TS2551: Property 'Commitments' does not exist on type 'PresentCommitmentData'. Did you mean 'commitments'?

336     commitments: presentCommitmentData.Commitments
                                           ~~~~~~~~~~~

  ui/lib/identity/index.ts:171:5
    171     commitments: Commitment[]
            ~~~~~~~~~~~
    'commitments' is declared here.

```