### PR TITLE
fix: Set min-width and min-height for icon in ListItem

### DIFF
--- a/ui/components/ListItem.svelte
+++ b/ui/components/ListItem.svelte
@@ -19,6 +19,8 @@
     .icon {
         height: 14vw;
         width: 14vw;
+        min-width: 14vw;
+        min-height: 14vw;
         border-radius: 50%;
         display: flex;
         align-items: center;


### PR DESCRIPTION
This resolves an issue on the home screen where the circle behind the logo becomes an oval if the logo is not square. The issue seems specific to Safari/iOS.