### PR TITLE
fix(ios): Fix crash in camera preview if not authorized

### DIFF
--- a/patches/capacitor-camera-preview+0.5.0.patch
+++ b/patches/capacitor-camera-preview+0.5.0.patch
@@ -34,3 +34,26 @@ index 477eeaa..6c36bbc 100644
  }
  
  
+diff --git a/node_modules/capacitor-camera-preview/ios/Plugin/Plugin.swift b/node_modules/capacitor-camera-preview/ios/Plugin/Plugin.swift
+index baa1be9..812d9c6 100644
+--- a/node_modules/capacitor-camera-preview/ios/Plugin/Plugin.swift
++++ b/node_modules/capacitor-camera-preview/ios/Plugin/Plugin.swift
+@@ -72,10 +72,14 @@ public class CameraPreview: CAPPlugin {
+ 
+     @objc func stop(_ call: CAPPluginCall) {
+         DispatchQueue.main.async {
+-            self.cameraController.captureSession?.stopRunning()
+-            self.previewView.removeFromSuperview()
+-            self.webView.isOpaque = true
+-            call.resolve()
++            if (self.cameraController.captureSession?.isRunning ?? false) {
++                self.cameraController.captureSession?.stopRunning()
++                self.previewView.removeFromSuperview()
++                self.webView.isOpaque = true
++                call.resolve()
++            } else {
++                call.reject("camera already stopped")
++            }
+         }
+     }
+ 


### PR DESCRIPTION
If the camera permission is not granted, a crash occurs on iOS when exiting the camera view (`Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value`). This is because `self.previewView` is `nil` if the `previewView` cannot be initialized in the `start` function (such as when the camera permission is not granted), so `self.previewView.removeFromSuperview()` cannot be called. This PR fixes the issue by matching the behavior on Android (checking if the camera is running before attempting to stop it and remove the view).