### PR TITLE
fix: Ensure settings button is not covered by the status bar

### DIFF
--- a/ui/views/Home.svelte
+++ b/ui/views/Home.svelte
@@ -82,6 +82,7 @@
         left: 0;
         top: 18px;
         padding-right: 18px;
+        padding-top: env(safe-area-inset-top, 0px);
     }
 
     .settings-button {


### PR DESCRIPTION
On an iPhone 11, the settings button is partially covered by the status bar. This PR fixes the issue by using `safe-area-inset-top` as the padding for the button. ﻿