### PR TITLE
Update README.md for running npx cap update android on missing files error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ To build the application for iOS or android, some additional [dependencies](http
 
 To start the build process, run `yarn ios` or `yarn android`.
 
+On getting the error saying capacitor-cordova-android-plugins/cordova.variables.gradle is missing, run `npx cap update android`.
+
 ## How to add custom credentials
 
 This chapter will guide you through the process of adding your own credential types to the Selv-App.


### PR DESCRIPTION
After a clean clone of the project, the android build fails caused by missing files in capacitor-cordova-android-plugins folder.
The folder is git ignored.
To create this folder the command `npx cap update android` can be used.
This was added to the README.md.